### PR TITLE
Fix tabs to work in mobile and desktop

### DIFF
--- a/src/components/lake/Documents.vue
+++ b/src/components/lake/Documents.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div>
+    <a name="documents" id="documents"></a>
     <h3>Documents</h3>
     <ul class="documents-wrapper">
       <li><a href="#">Basin Statistics (pdf)</a></li>

--- a/src/components/lake/LakeSideBar.vue
+++ b/src/components/lake/LakeSideBar.vue
@@ -18,7 +18,7 @@
 
       <div class="lake-summary">
 
-        <data-tabs :lake='lake' :with_sections='false'></data-tabs>
+        <data-tabs :lake='lake' :tabs_only='true'></data-tabs>
 
       <!-- <div class="summary-chart">
         <label>Area </label>

--- a/src/components/lake/Photos.vue
+++ b/src/components/lake/Photos.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div class="photos-wrapper">
+    <a name="photos" id='photos'></a>
     <h3>Photos</h3>
 
     <div class="photos">

--- a/src/components/lake/Tab.vue
+++ b/src/components/lake/Tab.vue
@@ -1,7 +1,7 @@
 <template>
   <li class='tab'>
     <router-link
-      v-bind:class="[active ? 'active' : '', 'tab-icon--'+section.name, 'tab-icon']"
+      :class="[active ? 'active' : '', 'tab-icon--'+section.name, , section.name, 'tab-icon']"
       :to="{
         name: 'lake',
         params: {'slug': lake.slug},

--- a/src/components/lake/Watershed.vue
+++ b/src/components/lake/Watershed.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div class="map-image--wrapper">
+    <a name="watershed" id="watershed"></a>
     <img src="~@/assets/watershed_fpo.jpg" />
     <p class="caption">
       <a href="#">Lake</a>|<a href="#">Watershed</a>

--- a/src/styles/datatabs.scss
+++ b/src/styles/datatabs.scss
@@ -1,8 +1,11 @@
+/*
 .tabs {
   li:last-of-type {
     display:none;
   }
 }
+*/
+
 /* Each tab is wrapped in a router a tag */
 
 .tabs {

--- a/src/views/Lake.vue
+++ b/src/views/Lake.vue
@@ -39,7 +39,6 @@
 
               <watershed></watershed>
               <documents></documents>
-              <photos></photos>
 
             </div>
 
@@ -62,7 +61,6 @@ import LakeCard from '@/components/lake/LakeCard';
 import DataTabs from '@/components/lake/DataTabs';
 import Watershed from '@/components/lake/Watershed';
 import Documents from '@/components/lake/Documents';
-import Photos from '@/components/lake/Photos';
 import AolMap from '@/components/map/AolMap';
 
 export default {
@@ -75,7 +73,6 @@ export default {
     DataTabs,
     Documents,
     Watershed,
-    Photos,
     AolMap
   },
   computed: {
@@ -203,10 +200,12 @@ export default {
 
   .body-sidebar {
     padding: 0px 0px 0px 50px;
+
     @include respond-to(handheld) {
       display: none;
       padding: 0px 15px;
     }
+
   }
 
 


### PR DESCRIPTION
- Show all tabs in map sidebar on all sizes
- On Mobile, all metadata components should
display in the body section
- On Desktop, Watershed and Documents are in the
right hand sidebar.
- Photos have been moved to the main body section