### PR TITLE
Set initial extent dynamically based on features

### DIFF
--- a/src/components/map/AolMap.vue
+++ b/src/components/map/AolMap.vue
@@ -135,6 +135,20 @@ export default {
                 console.error(e)
               })
             })
+
+            // reset extent to fit all features
+            // this lets the extent be viewable for any device
+            let lake_boundaries_layer = map.findLayerById(
+                'lake_bbox_service_layer');
+            lake_boundaries_layer.when(()=>{
+              return lake_boundaries_layer.queryExtent();
+            }).then((response) => {
+                let buffered_extent = response.extent.clone();
+                // add a little buffer and shift slightly
+                buffered_extent.expand(config.extent_buffer);
+                buffered_extent.offset(-60000, 1000, 0);
+                view.goTo(buffered_extent);
+            });
           });
           resolve();
         }).catch((e) => {

--- a/src/components/map/config.js
+++ b/src/components/map/config.js
@@ -69,11 +69,12 @@ const config = {
             async: true
         }
     },
-    map_center: [-121.7, 44.1],
-    zoom: 8,
+    //map_center: [-121.7, 44.1],
+    map_center: [-13547582.029541165, 5480930.47749898],
+    zoom: 7,
     minZoom: 7,
     maxZoom: 16,
-    extent_buffer: 1.1,
+    extent_buffer: 1.2,
     ArcGisOnlineServicesUrl: ArcGisOnlineServicesUrl,
     ArcGisOnlineTilesUrl: ArcGisOnlineTilesUrl,
     layers: [


### PR DESCRIPTION
Reset mapView extent after loading lake features
to include all features (plus a buffer)
This allows extent to be better aligned/sized on
various devices.