### PR TITLE
Renames Home view to Map.

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -3,7 +3,7 @@
 
     <div class="site-title">
       <h1>
-        <router-link :to="{name: 'home'}">
+        <router-link :to="{name: 'map'}">
           Atlas <span>of Oregon Lakes</span>
         </router-link>
       </h1>

--- a/src/components/lake/LakeSideBar.vue
+++ b/src/components/lake/LakeSideBar.vue
@@ -72,7 +72,7 @@ export default {
       return this.searchResults != null && this.searchResults.length;
     },
     back_href () {
-      return {name: 'home'};
+      return {name: 'map'};
     },
     lake_href () {
       return {name: 'lake', params: {reachcode: this.lake.reachcode}, hash: "#text-section"};

--- a/src/components/map/AolMap.vue
+++ b/src/components/map/AolMap.vue
@@ -75,7 +75,7 @@ export default {
                 if (reachcode == null || reachcode == '') {
                   console.debug("Selection does not provide a reachcode")
                   return
-                } else if (this.$route.name == 'home' &&
+                } else if (this.$route.name == 'map' &&
                            this.$route.query.lake == parseInt(reachcode)) {
                   console.warn("Selection made is the current selection");
                   return
@@ -86,7 +86,7 @@ export default {
 
                 if (lake != undefined && lake != null) {
                   console.debug("Loading waterbody " + reachcode + " from index");
-                  this.$router.push({name: 'home', query: {lake: lake.reachcode}});
+                  this.$router.push({name: 'map', query: {lake: lake.reachcode}});
                 } else {
                   console.debug("Waterbody " + reachcode + " not present in index");
                 }

--- a/src/components/map/MapContainer.vue
+++ b/src/components/map/MapContainer.vue
@@ -144,7 +144,7 @@ export default {
     goToInitialExtent () {
       if (Object.keys(this.$route.query).includes('lake') ||
           Object.keys(this.$route.query).includes('f')) {
-            this.$router.push({name: 'home'});
+            this.$router.push({name: 'map'});
       }
 
       this.$refs.map.resetBounds();

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -35,7 +35,7 @@ export default {
     },
     methods: {
         lake_href (lake) {
-            return {name: 'home', query: {'lake': lake.reachcode}};
+            return {name: 'map', query: {'lake': lake.reachcode}};
         },
         getMoreResults: _.debounce(
             function() {

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import Router from 'vue-router'
-import Home from './views/Home.vue'
 
 Vue.use(Router)
 
@@ -14,7 +13,12 @@ export default new Router({
     {
         path: '/',
         name: 'home',
-        component: Home,
+        redirect: '/map'
+    },
+    {
+        path: '/map',
+        name: 'map',
+        component: () => import(/* webpackChunkName: "map" */ './views/Map.vue')
     },
     {
         path: '/lake/:reachcode',

--- a/src/views/Lake.vue
+++ b/src/views/Lake.vue
@@ -79,10 +79,10 @@ export default {
   computed: {
     ...mapGetters({lake: 'getCurrentLake'}),
     sidebar_href () {
-      return {name: 'home', query: {lake: this.reachcode}};
+      return {name: 'map', query: {lake: this.reachcode}};
     },
     back_href () {
-      return {name: 'home'};
+      return {name: 'map'};
     },
     photo_style () {
       let photo = require('@/assets/generic_background.png');

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-bind:class="[focus ? 'sidebar_active' : '', 'home']">
+  <div v-bind:class="[focus ? 'sidebar_active' : '', 'map-view']">
     <side-bar class='sidebar-wrapper'
       v-bind:class="[focus ? 'sidebar_active' : '']">
     </side-bar>
@@ -16,7 +16,7 @@ import MapContainer from '@/components/map/MapContainer';
 import SideBar from '@/components/SideBar';
 
 export default {
-  name: 'home',
+  name: 'map',
   components: {
     MapContainer,
     SideBar
@@ -59,7 +59,7 @@ export default {
 
 <style lang="scss" scoped>
 
-.home {
+.map-view {
   display: grid;
   grid-template-columns: 0 auto;
   grid-template-areas: "sidebar map";


### PR DESCRIPTION
@conwayb @brennenf 

These changes rename the preexisting home view and create a replacement virtual view consisting of -  at the moment - a redirect.

The intent here is to provide future flexibility; e.g., in case we want to provide different behavior when navigating to the site root in order to initialize state differently. Personally, I think it's cleaner and I suspect the additional path component makes it the logical site organization clearer to end users.

I'm curious of your opinions and considerations (technical or design) I might have overlooked. This behavior is currently deployed into our staging environment should you like to toy around with it.