### PR TITLE
Provide 404 for dynamic flatpage paths

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,8 +6,9 @@
   <div id="app">
     <nav-bar v-bind:class="[!isOnline() ? 'offline' : '']"/>
     <offline-bar v-show="!isOnline()"/>
-    <error-bar v-if='error != null' :error="error"/>
-    <router-view />
+    <not-found v-if='error == "404"'/>
+    <error-bar v-if='error != "404" && error' :error="error"/>
+    <router-view v-else/>
   </div>
 </template>
 
@@ -17,10 +18,11 @@ import { mapActions } from 'vuex';
 import OfflineBar from '@/components/OfflineBar';
 import NavBar from '@/components/NavBar';
 import ErrorBar from '@/components/ErrorBar';
+import NotFound from '@/components/NotFound';
 
 export default {
   name: 'app',
-  components: { NavBar, OfflineBar, ErrorBar },
+  components: { NavBar, OfflineBar, ErrorBar, NotFound },
   computed: {
     error () {
       return this.$store.state.error;
@@ -38,7 +40,7 @@ export default {
      'aquatic-invasives',
      'about',
      'photo-submissions'].forEach((slug) => {
-        this.fetchPage(slug);
+        this.fetchPage({slug:slug, store:false});
     });
   },
   metaInfo: {

--- a/src/components/NotFound.vue
+++ b/src/components/NotFound.vue
@@ -10,7 +10,10 @@
           <h4>The page you're looking for could not be found.</h4>
           <p>
             Try going to the
-            <router-link :to="{ name: 'home'}">home page</router-link>
+            <router-link
+               @click.native="clearErrors"
+              :to="{ name: 'map'}">home page
+            </router-link>
             and searching &rarr;
           </p>
         </div>
@@ -19,3 +22,16 @@
     </div>
   </div>
 </template>
+
+<script>
+  import { mapActions } from 'vuex';
+
+  export default {
+    methods: {
+      ...mapActions(['setError']),
+      clearErrors () {
+        this.setError(null)
+      }
+    }
+  }
+</script>

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,8 @@ const VIEWPORTS = {
 const ERROR_TYPES = {
     APP: 'App level error. Non-recoverable',
     MAP: 'Some map element did not load or map interaction failed',
-    FETCH: 'Network connectivity or other backend issue'
+    FETCH: 'Network connectivity or other backend issue',
+    404: '404'
 }
 
 const config = {
@@ -35,7 +36,7 @@ const config = {
         return window.screen.width < VIEWPORTS.handset.width;
     },
     is_tablet: function(window) {
-        return (window.screen.width > VIEWPORTS.handset.width && 
+        return (window.screen.width > VIEWPORTS.handset.width &&
                 window.screen.width < VIEWPORTS.tablet.width);
     }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,9 +3,6 @@ import Router from 'vue-router'
 
 Vue.use(Router)
 
-const FlatPageRoutes = 'about|aquatic-invasives|bathymetry|photo-submissions';
-
-
 export default new Router({
   mode: 'history',
   base: process.env.BASE_URL,
@@ -36,17 +33,12 @@ export default new Router({
         }
     },
     {
-        path: `/:slug(${FlatPageRoutes})`,
+        path: `/:slug`,
         name: 'flatpage',
         props: (route) => ({
             slug: route.params.slug,
         }),
         component: () => import(/* webpackChunkName: "flatpage" */ '@/views/FlatPage.vue')
     },
-    {
-        path: '*',
-        name: '404',
-        component: () => import(/* webpackChunkName: "404" */ '@/views/404.vue')
-    }
   ]
 })

--- a/src/views/FlatPage.vue
+++ b/src/views/FlatPage.vue
@@ -14,7 +14,7 @@
           <div class="page-detail__nav detail__nav">
           </div>
           <div class="lake-card">
-            <div class="photo" :style="photo_style"></div> 
+            <div class="photo" :style="photo_style"></div>
             <div class="info">
               <h4>A Public Resource Since 1985</h4>
               <h2>{{ page.title }}</h2>
@@ -84,23 +84,11 @@ export default {
     }
   },
   created () {
-    if (this.isOnline()) {
-      // fetch the flatpage object from network
-      this.fetchPage(this.slug);
-    } else {
-      // fetch the flatpage object from cache
-      this.page = this.getCachedPage(this.slug);
-    }
+    this.fetchPage({slug:this.slug}).catch(() => {})
   },
   watch: {
     '$route': function () {
-      if (this.isOnline()) {
-        // fetch the flatpage object from network
-        this.fetchPage(this.slug);
-      } else {
-        // fetch the flatpage object from cache
-        this.page = this.getCachedPage(this.slug);
-      }
+      this.fetchPage({slug:this.slug});
     },
     'currentPage': function () {
       this.page = this.currentPage;


### PR DESCRIPTION
- Remove hardocded regex for flatpages routes
- Move 404 view to NotFound component
- Add new 404 error type
- Conditionally display ErrorBar, NotFound or RouterView based on
error state (in App.vue)
- Set 404 error in vuex state if client receives 4040 when trying
to fetch a faltpage
- Explicitly clearErrors when navigating away from 404 card